### PR TITLE
Downgrade Apache Derby version to fix missing JDBC bug, change Gradle dependency formatting

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,26 +21,27 @@ repositories {
 
 dependencies {
     implementation(
-            'com.jfoenix:jfoenix:8.0.9',
-            // you may comment out the database dependency you do not use
-            'org.xerial:sqlite-jdbc:3.30.1',
-            'org.apache.derby:derby:10.15.1.3',
+            [group: 'com.jfoenix', name: 'jfoenix', version: '8.0.9'],
+
+            // You may comment out the database dependency you do not use
+            [group: 'org.xerial', name: 'sqlite-jdbc', version: '3.30.1'],
+            [group: 'org.apache.derby',name: 'derby', version: '10.14.2.0'],
     )
 
     compileOnly(
-            'org.projectlombok:lombok:1.18.8'
+            [group: 'org.projectlombok', name: 'lombok', version: '1.18.8']
     )
 
     annotationProcessor(
-            'org.projectlombok:lombok:1.18.8'
+            [group: 'org.projectlombok', name: 'lombok', version: '1.18.8']
     )
 
     testImplementation(
-            'org.junit.jupiter:junit-jupiter:5.5.0',
-            'org.testfx:testfx-junit5:4.0.15-alpha'
+            [group: 'org.junit.jupiter', name: 'junit-jupiter', version: '5.5.0'],
+            [group: 'org.testfx', name: 'testfx-junit5', version: '4.0.15-alpha']
     )
     testRuntimeOnly(
-            "org.testfx:openjfx-monocle:8u76-b04"
+            [group: 'org.testfx', name: 'openjfx-monocle', version: '8u76-b04']
     )
 }
 


### PR DESCRIPTION
For some reason Apache Derby 10.15.x doesn't ship with the embedded JDBC client, and neither does the `derbyclient` artifact ([link](https://mvnrepository.com/artifact/org.apache.derby/derby)). The [10.15 release notes](https://db.apache.org/derby/releases/release-10.15.1.3.cgi#Release%20Notes%20for%20Apache%20Derby%2010.15.1.3) don't give much hint about why beyond the fact that Derby was repackaged as JPMS modules. Since Java modules are something that soft eng students can't be expected to be familiar with, it's probably best to downgrade anyways.

I also changed the format of the Gradle dependencies; they specify the same requirements, but they're a little more understandable and they follow the same Gradle format used on [the API hosting website](https://apisite.crmyers.dev/list).