### PR TITLE
Add API site to gradle by default

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,6 +10,9 @@ mainClassName = 'edu.wpi.teamname.Main'
 
 repositories {
     mavenCentral()
+    maven {
+    	url 'https://apisite.crmyers.dev/maven'
+    }
 }
 
 dependencies {


### PR DESCRIPTION
A lot of teams did not follow instructions to add the API site gradle to their build.gradle file. Hopefully adding it to the starter code by default will prevent that in the future.