### PR TITLE
Fix Travis CI build issue (build fail b/c permission denied)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ os: linux
 services:
     - xvfb
 
+before_install:
+  - chmod +x gradlew
+
 script:
   - ./gradlew check
 


### PR DESCRIPTION
One of my teammates encountered a build fail from Travis CI:
```
/home/travis/.travis/functions: line 351: ./gradlew: Permission denied
The command "eval ./gradlew assemble " failed 3 times.
The command "./gradlew assemble" failed and exited with 126 during .
Your build has been stopped.
```
This PR should fix said issue by making ```gradlew``` executable before it is executed in Travis CI