### PR TITLE
Fix ClassNotFound exceptions with most Google APIs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,8 +51,8 @@ jar {
     manifest {
         attributes 'Main-Class': mainClassName
     }
-    from {
-        configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) }
+    from configurations.runtimeClasspath.collect {
+        it.isDirectory() ? it : zipTree(it).matching{exclude{it.path.contains('META-INF')}}
     }
 }
 


### PR DESCRIPTION
This tweaks the dependency packing part of the build.gradle file so that it will automatically disregard the META-INF folder of dependencies. This solves a *lot* of problems.